### PR TITLE
Add CORS support so list-building tool can make requests

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,8 +5,10 @@ from flask import request
 import flask
 import toolforge
 from flask import jsonify
+from flask_cors import CORS
 
 app = flask.Flask(__name__)
+CORS(app)
 
 @app.route('/')
 def index():


### PR DESCRIPTION
The list-building tool was throwing CORS errors with your endpoint and I frankly don't fully understand how this works, but I always include the default CORS settings with Flask so I added them assuming that will solve the issue. Make sure the flask-cors library is available too: https://flask-cors.readthedocs.io/en/latest/